### PR TITLE
Fix failure of detection of recursive type unification

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -36,7 +36,10 @@ Fun is a minimal functional programming language that runs on the ecosystem of G
     - [ ] Type annotation
   - [ ] Record
   - [ ] Data type
-  - [ ] List
+  - [ ] Built-in types
+    - [ ] List
+    - [ ] Ref
+    - [ ] Option
   - [ ] Subtyping (structural subtyping)
 - [ ] Code generation
   - [ ] Go ast

--- a/pkg/types/type.go
+++ b/pkg/types/type.go
@@ -124,6 +124,5 @@ func (v *Var) Prune() Type {
 }
 
 func (c *CtorType) Prune() Type {
-	// todo: change to pointer method
 	return c
 }

--- a/pkg/typing/notes.md
+++ b/pkg/typing/notes.md
@@ -9,4 +9,3 @@ You could try to understand the overall control flow of the algorithm, and then 
 - A tutorial explaining the [basic polynomial typechecking](http://lucacardelli.name/Papers/BasicTypechecking.pdf).
 - The HindleyMilner algorithm implemented in [Scala](http://dysphoria.net/code/hindley-milner/HindleyMilner.scala).
 - A type inference implementation in [miniml](https://github.com/cmaes/miniml/blob/master/typing.ml#L74).
-- 


### PR DESCRIPTION
To solve the issue, I consulted various reference implementations and documents, and finally found a solution. The context and cases has been explained in details in page 10-11 of the [doc](http://lucacardelli.name/Papers/BasicTypechecking.pdf).

In other words, when we go into a function scope, all the type variables that occur in the type of the function have to be added to the non-generic variable set. So the bug in the current implementation, is that **the result type var of the function is not added to the set**. Therefore, the fix is easy.